### PR TITLE
Update to 1.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 apply plugin: 'maven'
 
 group 'org.wycliffeassociates'
-version '1.5.1'
+version '1.5.2'
 
 repositories {
     jcenter()

--- a/src/test/java/org/wycliffeassociates/usfmtools/USFMParserTest.java
+++ b/src/test/java/org/wycliffeassociates/usfmtools/USFMParserTest.java
@@ -483,4 +483,15 @@ public class USFMParserTest {
     private void isInstanceOfType(Object obj, Class clazz) {
         Assert.assertThat(obj, instanceOf(clazz));
     }
+
+    /**
+     * Verify that if a \q marker is at the end of a string it doesn't throw an exception
+     */
+    @Test
+    public void TestTrailingEmptyQMarker()
+    {
+        String verseText = "\\q";
+        var output = parser.parseFromString(verseText);
+        isInstanceOfType(output.contents.get(0), QMarker.class);
+    }
 }


### PR DESCRIPTION
1.5.2 adds a bounds check to parseFromString() in USFMParser, but this bounds check already existed in USFMToolsJava

This commit updates the version number and adds a unit test that was introduced in 1.5.2