### PR TITLE
Allow WMarker term as textblock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 apply plugin: 'maven'
 
 group 'org.wycliffeassociates'
-version '1.9.1'
+version '1.9.2-proposedfix'
 
 repositories {
     jcenter()

--- a/src/main/java/org/wycliffeassociates/usfmtools/models/markers/WMarker.java
+++ b/src/main/java/org/wycliffeassociates/usfmtools/models/markers/WMarker.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
  * Wordlist / Glossary / Dictionary Entry Marker
  */
 public class WMarker extends Marker {
+
     public String term;
     public HashMap<String, String> attributes;
     private static Pattern wordAttrPattern = Pattern.compile("([\\w-]+)=?\"?([\\w,:.]*)\"?", Pattern.DOTALL);
@@ -38,7 +39,15 @@ public class WMarker extends Marker {
             }
         }
 
-        return "";
+        return term;
     }
 
+    @Override
+    public ArrayList<java.lang.Class> getAllowedContents() {
+        return new ArrayList<java.lang.Class>(
+                Arrays.asList(
+                        TextBlock.class
+                )
+        );
+    }
 }


### PR DESCRIPTION
Uses the term as a textblock so that words in a word marker are rendered out when getting textblocks of a higher marker such as VMarker.